### PR TITLE
explicit line-height on current year input

### DIFF
--- a/mbgl-control-timeslider-control.scss
+++ b/mbgl-control-timeslider-control.scss
@@ -153,6 +153,7 @@ $numberbgcolor: white;
             color: $defaulttextcolor;
             font-weight: bold;
             font-size: 18px;
+            line-height: 20px;
         }
     }
 


### PR DESCRIPTION
Refer to https://github.com/OpenHistoricalMap/issues/issues/373

This adds to the stylesheet an explicit line-height for the current-year number input. This prevents a problem in some stylesheets (newer Leaflet, updated OSM/OHM) where the inherited line-height has changed, causing the slider to be pushed down.